### PR TITLE
Remove `global` definition from `vite.config.ts`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,9 +6,6 @@ import { imagetools } from "vite-imagetools";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  define: {
-    "global": {},
-  },
   plugins: [
     react(),
     viteCompression(),


### PR DESCRIPTION
This caused some dependencies to fail to build in Docker.