### PR TITLE
Define `global` as `globalThis` in `vite.config.ts`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,9 @@ import { imagetools } from "vite-imagetools";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  define: {
+    global: "globalThis"
+  },
   plugins: [
     react(),
     viteCompression(),


### PR DESCRIPTION
`zilliqa-js` depends on `pbkdf2` which uses `global`. This is a node builtin and so libraries shouldn't depend on it.

More information in:
https://github.com/vitejs/vite/discussions/5912