### PR TITLE
Add ability to search using Bech32 address

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,7 @@ const App = () => {
                     />
                     <Route path="tx/:txhash/*" element={<Transaction />} />
                     <Route
-                      path="address/:addressOrName/*"
+                      path="address/:unchecked_addressOrName/*"
                       element={<Address />}
                     />
                     {runtime.config?.experimental && (

--- a/src/execution/AddressMainPage.tsx
+++ b/src/execution/AddressMainPage.tsx
@@ -25,15 +25,20 @@ import { useHasCode } from "../useErigonHooks";
 import { useAddressOrENS } from "../useResolvedAddresses";
 import { useSourcifyMetadata } from "../sourcify/useSourcify";
 import { ChecksummedAddress } from "../types";
+import { fromBech32Address } from '@zilliqa-js/crypto'
+import { validation } from '@zilliqa-js/util'
 
 type AddressMainPageProps = {};
 
 const AddressMainPage: React.FC<AddressMainPageProps> = () => {
-  const { addressOrName, direction } = useParams();
-  if (addressOrName === undefined) {
+  const { unchecked_addressOrName, direction } = useParams();
+  if (unchecked_addressOrName === undefined) {
     throw new Error("addressOrName couldn't be undefined here");
   }
 
+  const addressOrName = validation.isBech32(unchecked_addressOrName) ?
+    fromBech32Address(unchecked_addressOrName).toLowerCase() : unchecked_addressOrName;
+  
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const urlFixer = useCallback(

--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -25,8 +25,8 @@ const AddressTransactionResults: FC<AddressAwareComponentProps> = ({
   const { provider } = useContext(RuntimeContext);
   const [feeDisplay, feeDisplayToggler] = useFeeToggler();
 
-  const { addressOrName, direction } = useParams();
-  if (addressOrName === undefined) {
+  const { unchecked_addressOrName, direction } = useParams();
+  if (unchecked_addressOrName === undefined) {
     throw new Error("addressOrName couldn't be undefined here");
   }
 


### PR DESCRIPTION
Users are now able to search for addresses using a Bech32 address.

This was done by updating the variable in the URL in App.tsx, adding a check in AdressMainPage.tsx and updating the struct which is created by the result of `useParams()`.