### PR TITLE
Display blocks

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -10,8 +10,9 @@ import { useGenericSearch } from "./search/search";
 import Otter from "./otter.png?w=64&h=64&webp";
 
 const CameraScanner = lazy(() => import("./search/CameraScanner"));
+type HeaderProps = {sourcifyPresent : boolean };
 
-const Header: FC = () => {
+const Header: FC<HeaderProps> = ({sourcifyPresent}) => {
   const { provider } = useContext(RuntimeContext);
   const [searchRef, handleChange, handleSubmit] = useGenericSearch();
   const [isScanning, setScanning] = useState<boolean>(false);
@@ -66,7 +67,7 @@ const Header: FC = () => {
               Search
             </button>
           </form>
-          <SourcifyMenu />
+          {sourcifyPresent && <SourcifyMenu/>} 
         </div>
       </div>
     </>

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -10,6 +10,7 @@ import { useLatestBlockHeader } from "./useLatestBlock";
 import { blockURL, slotURL } from "./url";
 import { useGenericSearch } from "./search/search";
 import { useFinalizedSlotNumber, useSlotTimestamp } from "./useConsensus";
+import Header from "./Header";
 
 const CameraScanner = lazy(() => import("./search/CameraScanner"));
 
@@ -20,51 +21,13 @@ const Home: FC = () => {
   const latestBlock = useLatestBlockHeader(provider);
   const finalizedSlotNumber = useFinalizedSlotNumber();
   const slotTime = useSlotTimestamp(finalizedSlotNumber);
-  const [isScanning, setScanning] = useState<boolean>(false);
 
   document.title = "Home | Otterscan";
 
   return (
-    <div className="flex grow flex-col items-center pb-5">
-      {isScanning && <CameraScanner turnOffScan={() => setScanning(false)} />}
-      <div className="mt-5 mb-10 flex max-h-64 grow items-end">
-        <Logo />
-      </div>
-      <form
-        className="flex w-1/3 flex-col"
-        onSubmit={handleSubmit}
-        autoComplete="off"
-        spellCheck={false}
-      >
-        <div className="mb-10 flex">
-          <input
-            className="w-full rounded-l border-l border-t border-b px-2 py-1 focus:outline-none"
-            type="text"
-            size={50}
-            placeholder={`Search by address / txn hash / block number${
-              provider?.network.ensAddress ? " / ENS name" : ""
-            }`}
-            onChange={handleChange}
-            ref={searchRef}
-            autoFocus
-          />
-          <button
-            className="flex items-center justify-center rounded-r border bg-skin-button-fill px-2 py-1 text-base text-skin-button hover:bg-skin-button-hover-fill focus:outline-none"
-            type="button"
-            onClick={() => setScanning(true)}
-            title="Scan an ETH address using your camera"
-          >
-            <FontAwesomeIcon icon={faQrcode} />
-          </button>
-        </div>
-        <button
-          className="mx-auto mb-10 rounded bg-skin-button-fill px-3 py-1 hover:bg-skin-button-hover-fill focus:outline-none"
-          type="submit"
-        >
-          Search
-        </button>
-      </form>
-      <div className="text-lg font-bold text-link-blue hover:text-link-blue-hover">
+    <>
+      <Header sourcifyPresent= {false} />
+      <div className="flex grow flex-col items-center pb-5 text-lg font-bold text-link-blue hover:text-link-blue-hover">
         {provider?.network.chainId !== 11155111 && (
           <NavLink to="/special/london">
             <div className="flex items-baseline space-x-2 text-orange-500 hover:text-orange-700 hover:underline">
@@ -97,7 +60,7 @@ const Home: FC = () => {
           {slotTime && <Timestamp value={slotTime} />}
         </NavLink>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -9,7 +9,7 @@ import { useLatestBlockHeader } from "./useLatestBlock";
 import { blockURL, slotURL } from "./url";
 import { useFinalizedSlotNumber, useSlotTimestamp } from "./useConsensus";
 import Header from "./Header";
-import RecentBlocks from "./execution/block/recentBlocks";
+import RecentBlocks from "./execution/block/RecentBlocks";
 
 
 const Home: FC = () => {

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,22 +1,19 @@
-import { useState, useContext, lazy, FC, memo } from "react";
+import { useContext, FC, memo } from "react";
 import { NavLink } from "react-router-dom";
 import { commify } from "@ethersproject/units";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faBurn, faQrcode } from "@fortawesome/free-solid-svg-icons";
-import Logo from "./Logo";
+import { faBurn } from "@fortawesome/free-solid-svg-icons";
 import Timestamp from "./components/Timestamp";
 import { RuntimeContext } from "./useRuntime";
 import { useLatestBlockHeader } from "./useLatestBlock";
 import { blockURL, slotURL } from "./url";
-import { useGenericSearch } from "./search/search";
 import { useFinalizedSlotNumber, useSlotTimestamp } from "./useConsensus";
 import Header from "./Header";
+import RecentBlocks from "./execution/block/recentBlocks";
 
-const CameraScanner = lazy(() => import("./search/CameraScanner"));
 
 const Home: FC = () => {
   const { provider } = useContext(RuntimeContext);
-  const [searchRef, handleChange, handleSubmit] = useGenericSearch();
 
   const latestBlock = useLatestBlockHeader(provider);
   const finalizedSlotNumber = useFinalizedSlotNumber();
@@ -27,6 +24,7 @@ const Home: FC = () => {
   return (
     <>
       <Header sourcifyPresent= {false} />
+      <RecentBlocks />
       <div className="flex grow flex-col items-center pb-5 text-lg font-bold text-link-blue hover:text-link-blue-hover">
         {provider?.network.chainId !== 11155111 && (
           <NavLink to="/special/london">

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -17,7 +17,7 @@ const Main: React.FC = () => {
 
   return (
     <AppConfigContext.Provider value={appConfig}>
-      <Header />
+      <Header sourcifyPresent={true} />
       <Outlet />
     </AppConfigContext.Provider>
   );

--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -7,8 +7,8 @@ import NativeTokenAmountAndFiat from "../../components/NativeTokenAmountAndFiat"
 import { balancePreset } from "../../components/FiatValue";
 import TransactionAddressWithCopy from "../components/TransactionAddressWithCopy";
 import TransactionLink from "../../components/TransactionLink";
-import PendingResults from "../../search/PendingResults";
-import ResultHeader from "../../search/ResultHeader";
+import PendingTransactionResults from "../../search/PendingTransactionResults";
+import TransactionResultHeader from "../../search/TransactionResultHeader";
 import { SearchController } from "../../search/search";
 import TransactionItem from "../../search/TransactionItem";
 import UndefinedPageControl from "../../search/UndefinedPageControl";
@@ -118,7 +118,7 @@ const AddressTransactionResults: FC<AddressAwareComponentProps> = ({
           )}
         </BlockNumberContext.Provider>
         <NavBar address={address} page={page} controller={controller} />
-        <ResultHeader
+        <TransactionResultHeader
           feeDisplay={feeDisplay}
           feeDisplayToggler={feeDisplayToggler}
         />
@@ -135,7 +135,7 @@ const AddressTransactionResults: FC<AddressAwareComponentProps> = ({
             <NavBar address={address} page={page} controller={controller} />
           </>
         ) : (
-          <PendingResults />
+          <PendingTransactionResults />
         )}
       </StandardSelectionBoundary>
     </ContentFrame>

--- a/src/execution/block/BlockTransactionResults.tsx
+++ b/src/execution/block/BlockTransactionResults.tsx
@@ -2,8 +2,8 @@ import { FC, memo } from "react";
 import ContentFrame from "../../components/ContentFrame";
 import StandardSelectionBoundary from "../../selection/StandardSelectionBoundary";
 import SearchResultNavBar from "../../search/SearchResultNavBar";
-import ResultHeader from "../../search/ResultHeader";
-import PendingResults from "../../search/PendingResults";
+import TransactionResultHeader from "../../search/TransactionResultHeader";
+import PendingTransactionResults from "../../search/PendingTransactionResults";
 import TransactionItem from "../../search/TransactionItem";
 import { useFeeToggler } from "../../search/useFeeToggler";
 import { totalTransactionsFormatter } from "../../search/messages";
@@ -33,7 +33,7 @@ const BlockTransactionResults: FC<BlockTransactionResultsProps> = ({
         total={total}
         totalFormatter={totalTransactionsFormatter}
       />
-      <ResultHeader
+      <TransactionResultHeader
         feeDisplay={feeDisplay}
         feeDisplayToggler={feeDisplayToggler}
       />
@@ -50,7 +50,7 @@ const BlockTransactionResults: FC<BlockTransactionResultsProps> = ({
           />
         </StandardSelectionBoundary>
       ) : (
-        <PendingResults />
+        <PendingTransactionResults />
       )}
     </ContentFrame>
   );

--- a/src/execution/block/recentBlocks.tsx
+++ b/src/execution/block/recentBlocks.tsx
@@ -1,0 +1,49 @@
+import { FC, useContext, memo } from "react";
+import ContentFrame from "../../components/ContentFrame";
+import StandardSelectionBoundary from "../../selection/StandardSelectionBoundary";
+import { useFeeToggler } from "../../search/useFeeToggler";
+import { RuntimeContext } from "../../useRuntime";
+import { useRecentBlocks } from "../../useErigonHooks";
+import { useLatestBlockHeader } from "../../useLatestBlock";
+import { RECENT_SIZE } from "../../params";
+import BlockItem from "../../search/BlockItem";
+import BlockResultHeader from "../../search/BlockResultHeader";
+import PendingBlockResults from "../../search/PendingBlockResults";
+
+
+
+const RecentBlocks: FC = () => {
+  const { provider } = useContext(RuntimeContext);
+  const [feeDisplay, feeDisplayToggler] = useFeeToggler();
+
+  const latestBlock = useLatestBlockHeader(provider);
+  const latestBlockNum = latestBlock?.number;
+
+  // Uses hook to get the most recent blocks
+  const { data, isLoading } = useRecentBlocks(
+    provider,
+    latestBlockNum,
+    RECENT_SIZE
+  );
+
+  // Return a table with rows containing the basic information of the most recent RECENT_SIZE blocks
+  return (
+    <ContentFrame isLoading={isLoading}>
+      <BlockResultHeader
+        feeDisplay={feeDisplay}
+        feeDisplayToggler={feeDisplayToggler}
+      />
+      {data ? (
+        <StandardSelectionBoundary>
+          {data.map((block) => (
+            block ? <BlockItem key={block.number} block={block} feeDisplay={feeDisplay} /> : <></> 
+          ))}
+        </StandardSelectionBoundary>
+      ) : (
+        <PendingBlockResults />
+      )}
+    </ContentFrame>
+  );
+};
+
+export default memo(RecentBlocks);

--- a/src/execution/block/recentBlocks.tsx
+++ b/src/execution/block/recentBlocks.tsx
@@ -9,7 +9,7 @@ import { RECENT_SIZE } from "../../params";
 import BlockItem from "../../search/BlockItem";
 import BlockResultHeader from "../../search/BlockResultHeader";
 import PendingBlockResults from "../../search/PendingBlockResults";
-
+import RecentNavBar from "../../search/RecentNavBar";
 
 
 const RecentBlocks: FC = () => {
@@ -29,6 +29,7 @@ const RecentBlocks: FC = () => {
   // Return a table with rows containing the basic information of the most recent RECENT_SIZE blocks
   return (
     <ContentFrame isLoading={isLoading}>
+      <RecentNavBar isLoading={ data === undefined }/>
       <BlockResultHeader
         feeDisplay={feeDisplay}
         feeDisplayToggler={feeDisplayToggler}

--- a/src/params.ts
+++ b/src/params.ts
@@ -1,3 +1,3 @@
 export const MIN_API_LEVEL = 8;
-
+export const RECENT_SIZE = 5;
 export const PAGE_SIZE = 25;

--- a/src/search/BlockItem.tsx
+++ b/src/search/BlockItem.tsx
@@ -1,0 +1,53 @@
+import React, { useContext } from "react";
+import BlockLink from "../components/BlockLink";
+import TimestampAge from "../components/TimestampAge";
+import TransactionItemFiatFee from "./TransactionItemFiatFee";
+import { FeeDisplay } from "./useFeeToggler";
+import { RuntimeContext } from "../useRuntime";
+import { ExtendedBlock } from "../useErigonHooks";
+import { formatValue } from "../components/formatter";
+import { blockTxsURL } from "../url";
+import { NavLink } from "react-router-dom";
+import BlockReward from "../execution/components/BlockReward";
+
+type BlockItemProps = {
+  block: ExtendedBlock,
+  feeDisplay: FeeDisplay
+};
+
+const BlockItem: React.FC<BlockItemProps> = ({ block, feeDisplay}) => {
+  const { provider } = useContext(RuntimeContext);
+
+
+  return (
+    <div
+    className="grid grid-cols-5 items-baseline gap-x-1 border-t border-gray-200 text-sm 
+    hover:bg-skin-table-hover px-2 py-3"
+    >
+    <span>
+    <BlockLink blockTag={block.number} />
+    </span>
+    <span>
+    <NavLink
+        className="rounded-lg bg-link-blue/10 px-2 py-1 text-xs text-link-blue hover:bg-link-blue/100 hover:text-white"
+        to={blockTxsURL(block.number)}
+    >
+        {block.transactionCount} transactions
+    </NavLink>{" "}
+    </span>
+    <span className="truncate font-balance text-xs text-gray-500">
+        {feeDisplay === FeeDisplay.TX_FEE && formatValue(block.feeReward, 18)}
+        {feeDisplay === FeeDisplay.TX_FEE_USD && (
+        <TransactionItemFiatFee blockTag={block.number} fee={block.feeReward} />
+        )}
+        {feeDisplay === FeeDisplay.GAS_PRICE && formatValue(block.gasUsed, 9)}
+    </span>
+    <span>
+        <BlockReward block={block} />
+    </span>
+    <TimestampAge timestamp={block.timestamp}/>
+    </div>
+  );
+};
+
+export default BlockItem;

--- a/src/search/BlockResultHeader.tsx
+++ b/src/search/BlockResultHeader.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { FeeDisplay } from "./useFeeToggler";
+
+export type ResultHeaderProps = {
+    feeDisplay: FeeDisplay,
+    feeDisplayToggler: () => void
+};
+
+const BlockResultHeader: React.FC<ResultHeaderProps> = ({
+    feeDisplay,
+    feeDisplayToggler
+}) => (
+  <div className="grid grid-cols-5 gap-x-1 border-t border-b border-gray-200 bg-gray-100 px-2 py-2 text-sm font-bold text-gray-500">
+    <div>Height</div>
+    <div>Txns</div>
+    <div>
+      <button
+        className="text-link-blue hover:text-link-blue-hover"
+        onClick={feeDisplayToggler}
+      >
+        {feeDisplay === FeeDisplay.TX_FEE && "Txn Fee"}
+        {feeDisplay === FeeDisplay.TX_FEE_USD && "Txn Fee (USD)"}
+        {feeDisplay === FeeDisplay.GAS_PRICE && "Gas Price"}
+      </button>
+    </div>
+    <div>Rewards</div>
+    <div>Age</div>
+  </div>
+);
+
+export default React.memo(BlockResultHeader);

--- a/src/search/PendingBlockResults.tsx
+++ b/src/search/PendingBlockResults.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+const PendingBlockResults: React.FC = () => (
+  <div className="grid animate-pulse grid-cols-5 items-baseline gap-x-1 border-t border-gray-200 px-2 py-3 text-sm">
+    <div className="col-span-1 h-5 w-full rounded bg-gradient-to-r from-gray-100 to-transparent"></div>
+    <div className="col-span-1 h-5 w-full rounded bg-gradient-to-r from-gray-100 to-transparent"></div>
+    <div className="col-span-1 h-5 w-full rounded bg-gradient-to-r from-gray-100 to-transparent"></div>
+    <div className="col-span-1 h-5 w-full rounded bg-gradient-to-r from-gray-100 to-transparent"></div>
+    <div className="col-span-1 h-5 w-full rounded bg-gradient-to-r from-gray-100 to-transparent"></div>
+  </div>
+);
+
+export default React.memo(PendingBlockResults);

--- a/src/search/PendingTransactionResults.tsx
+++ b/src/search/PendingTransactionResults.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const PendingResults: React.FC = () => (
+const PendingTransactionResults: React.FC = () => (
   <div className="grid animate-pulse grid-cols-12 items-baseline gap-x-1 border-t border-gray-200 px-2 py-3 text-sm">
     <div className="col-span-2 h-5 w-full rounded bg-gradient-to-r from-gray-100 to-transparent"></div>
     <div className="col-span-1 h-5 w-full rounded bg-gradient-to-r from-gray-100 to-transparent"></div>
@@ -13,4 +13,4 @@ const PendingResults: React.FC = () => (
   </div>
 );
 
-export default React.memo(PendingResults);
+export default React.memo(PendingTransactionResults);

--- a/src/search/RecentNavBar.tsx
+++ b/src/search/RecentNavBar.tsx
@@ -1,0 +1,18 @@
+import { FC, ReactNode, memo } from "react";
+import PageControl from "./PageControl";
+
+type RecentNavBarProps = {
+    isLoading : boolean
+};
+
+const RecentNavBar: FC<RecentNavBarProps> = ({ isLoading }) => (
+  <div className="flex items-baseline justify-between py-3">
+    <div className="text-sm text-gray-500">
+      {isLoading
+        ? "Waiting for blocks..."
+        : "Transaction Blocks"}
+    </div>
+  </div>
+);
+
+export default memo(RecentNavBar);

--- a/src/search/TransactionResultHeader.tsx
+++ b/src/search/TransactionResultHeader.tsx
@@ -6,7 +6,7 @@ export type ResultHeaderProps = {
   feeDisplayToggler: () => void;
 };
 
-const ResultHeader: React.FC<ResultHeaderProps> = ({
+const TransactionResultHeader: React.FC<ResultHeaderProps> = ({
   feeDisplay,
   feeDisplayToggler,
 }) => (
@@ -31,4 +31,4 @@ const ResultHeader: React.FC<ResultHeaderProps> = ({
   </div>
 );
 
-export default React.memo(ResultHeader);
+export default React.memo(TransactionResultHeader);


### PR DESCRIPTION
I revamped the front page to display the most `RECENT_SIZE` recent blocks.

The first commit involves replacing the large central search bar with the search bar that appears when not on the home page, e.g. the page displaying a Block. This would give space to add more information.

The second commit involves me duplicating the `BlockTransactionResults.tsx` into the new `recentBlocks.tsx`. This involved creating new `BlockResultHeader.tsx`, `BlockItem.tsx` and `PendingBlockResults.tsx` which have different columns and handle a new data structure compared to `TransactionItem.tsx` and the now renamed `PendingTransactionResults` and `TransactionResultHeader`.

When future features are added to the Home page, I will make sure to reduce the width of the table.