### PR TITLE
Fix call to ots_getCode() for ZQ1 so that contracts are displayed properly again

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -111,7 +111,7 @@ const Home: FC = () => {
           >
             <div>Latest block: {commify(latestBlock.number)}</div>
             <Timestamp value={latestBlock.timestamp} />
-            <div>Ziliqa Otterscan Version: {config?.version}</div>
+            <div>Zilliqa Otterscan Version: {config?.version}pl1</div>
           </NavLink>
         )}
         {finalizedSlotNumber !== undefined && (

--- a/src/search/TransactionResultHeader.tsx
+++ b/src/search/TransactionResultHeader.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FeeDisplay } from "./useFeeToggler";
+import StandardTHead from "../components/StandardTHead";
 
 export type ResultHeaderProps = {
   feeDisplay: FeeDisplay;
@@ -10,15 +11,15 @@ const TransactionResultHeader: React.FC<ResultHeaderProps> = ({
   feeDisplay,
   feeDisplayToggler,
 }) => (
-  <div className="grid grid-cols-12 gap-x-1 border-b border-t border-gray-200 bg-gray-100 px-2 py-2 text-sm font-bold text-gray-500">
-    <div className="col-span-2">Txn Hash</div>
-    <div>Method</div>
-    <div>Block</div>
-    <div>Age</div>
-    <div className="col-span-2 ml-1">From</div>
-    <div className="col-span-2 ml-1">To</div>
-    <div className="col-span-2">Value</div>
-    <div>
+  <StandardTHead>
+    <th>Txn Hash</th>
+    <th>Method</th>
+    <th className="w-28">Block</th>
+    <th className="w-36">Age</th>
+    <th>From</th>
+    <th>To</th>
+    <th className="min-w-52">Value</th>
+    <th>
       <button
         className="text-link-blue hover:text-link-blue-hover"
         onClick={feeDisplayToggler}
@@ -27,8 +28,8 @@ const TransactionResultHeader: React.FC<ResultHeaderProps> = ({
         {feeDisplay === FeeDisplay.TX_FEE_USD && "Txn Fee (USD)"}
         {feeDisplay === FeeDisplay.GAS_PRICE && "Gas Price"}
       </button>
-    </div>
-  </div>
+    </th>
+  </StandardTHead>
 );
 
 export default React.memo(TransactionResultHeader);

--- a/src/search/TransactionResultHeader.tsx
+++ b/src/search/TransactionResultHeader.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { FeeDisplay } from "./useFeeToggler";
 import StandardTHead from "../components/StandardTHead";
+import { FeeDisplay } from "./useFeeToggler";
 
 export type ResultHeaderProps = {
   feeDisplay: FeeDisplay;

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -30,7 +30,7 @@ import {
   TokenTransfer,
   TransactionData,
 } from "./types";
-import { useQuirks, Quirks} from "./useQuirks";
+import { useQuirks } from "./useQuirks";
 import { formatter } from "./utils/formatter";
 
 const TRANSFER_TOPIC =

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -30,6 +30,7 @@ import {
   TokenTransfer,
   TransactionData,
 } from "./types";
+import { useQuirks, Quirks} from "./useQuirks";
 import { formatter } from "./utils/formatter";
 
 const TRANSFER_TOPIC =
@@ -420,13 +421,15 @@ export const useInternalOperations = (
     }
 
     const _t: InternalOperation[] = [];
-    for (const t of data) {
-      _t.push({
-        type: t.type,
-        from: formatter.address(getAddress(t.from)),
-        to: formatter.address(getAddress(t.to)),
-        value: formatter.bigInt(t.value),
-      });
+    if (data) {
+      for (const t of data) {
+        _t.push({
+          type: t.type,
+          from: formatter.address(getAddress(t.from)),
+          to: formatter.address(getAddress(t.to)),
+          value: formatter.bigInt(t.value),
+        });
+      }
     }
     return _t;
   }, [provider, data]);
@@ -782,6 +785,12 @@ export const useHasCode = (
   blockTag: BlockTag = "latest",
 ): boolean | undefined => {
   const fetcher = providerFetcher(provider);
+  const quirks = useQuirks(provider);
+  if (quirks?.isZilliqa1) {
+    // Zilliqa 1 requires that the tag be numeric, but ignores it, so we can
+    // use 0 and save ourselves a fetch.
+    blockTag = 0;
+  }
   const { data, error } = useSWRImmutable(
     ["ots_hasCode", address, blockTag],
     fetcher,

--- a/src/useQuirks.ts
+++ b/src/useQuirks.ts
@@ -1,0 +1,30 @@
+import {
+  JsonRpcApiProvider
+} from "ethers";
+import { useEffect, useMemo, useState } from "react";
+import useSWR, { Fetcher } from "swr";
+import useSWRImmutable from "swr/immutable";
+
+export type Quirks = {
+  // Zilliqa 1 has so many odd quirks that we just have to declare it ..
+  isZilliqa1: boolean;
+}
+
+type ZilliqaVersion = {
+  Commit: string;
+  Version: string;
+}
+
+export const quirksFetcher = (provider : JsonRpcApiProvider | undefined ):  Fetcher<any,Quirks> => async (key) =>{
+  const version = await provider?.send("GetVersion", []);
+  const isZilliqa1 = version?.Version.match(/^v9.[0-9]+/);
+  console.log(`version ${JSON.stringify(version)} is Zilliqa 1? {isZilliqa1}`);
+  return {
+    isZilliqa1
+  }
+}
+
+export const useQuirks = (provider: JsonRpcApiProvider | undefined) : Quirks => {
+  const { data : quirks } = useSWRImmutable("getVersion", quirksFetcher(provider));
+  return quirks;
+}

--- a/src/useQuirks.ts
+++ b/src/useQuirks.ts
@@ -1,30 +1,31 @@
-import {
-  JsonRpcApiProvider
-} from "ethers";
-import { useEffect, useMemo, useState } from "react";
-import useSWR, { Fetcher } from "swr";
+import { JsonRpcApiProvider } from "ethers";
+import { Fetcher } from "swr";
 import useSWRImmutable from "swr/immutable";
 
 export type Quirks = {
   // Zilliqa 1 has so many odd quirks that we just have to declare it ..
   isZilliqa1: boolean;
-}
+};
 
 type ZilliqaVersion = {
   Commit: string;
   Version: string;
-}
+};
 
-export const quirksFetcher = (provider : JsonRpcApiProvider | undefined ):  Fetcher<any,Quirks> => async (key) =>{
-  const version = await provider?.send("GetVersion", []);
-  const isZilliqa1 = version?.Version.match(/^v9.[0-9]+/);
-  console.log(`version ${JSON.stringify(version)} is Zilliqa 1? {isZilliqa1}`);
-  return {
-    isZilliqa1
-  }
-}
+export const quirksFetcher =
+  (provider: JsonRpcApiProvider | undefined): Fetcher<any, Quirks> =>
+  async (key) => {
+    const version = await provider?.send("GetVersion", []);
+    const isZilliqa1 = version?.Version.match(/^v9.[0-9]+/);
+    return {
+      isZilliqa1,
+    };
+  };
 
-export const useQuirks = (provider: JsonRpcApiProvider | undefined) : Quirks => {
-  const { data : quirks } = useSWRImmutable("getVersion", quirksFetcher(provider));
+export const useQuirks = (provider: JsonRpcApiProvider | undefined): Quirks => {
+  const { data: quirks } = useSWRImmutable(
+    "getVersion",
+    quirksFetcher(provider),
+  );
   return quirks;
-}
+};

--- a/src/useQuirks.ts
+++ b/src/useQuirks.ts
@@ -18,7 +18,7 @@ export const quirksFetcher =
     const version = await provider?.send("GetVersion", []);
     const isZilliqa1 = version?.Version.match(/^v9.[0-9]+/);
     return {
-      isZilliqa1,
+      isZilliqa1: !!isZilliqa1,
     };
   };
 

--- a/src/useZilliqaHooks.ts
+++ b/src/useZilliqaHooks.ts
@@ -102,4 +102,3 @@ export const useBlockChainInfo = (
   }
   return { data, isLoading };
 };
-

--- a/src/useZilliqaHooks.ts
+++ b/src/useZilliqaHooks.ts
@@ -102,3 +102,4 @@ export const useBlockChainInfo = (
   }
   return { data, isLoading };
 };
+


### PR DESCRIPTION
(also, fixes up the header for address display - the rest of otterscan moved to using a table; we didn't).